### PR TITLE
feat: add conditional archiving of tasks

### DIFF
--- a/examples/archive.rs
+++ b/examples/archive.rs
@@ -19,7 +19,9 @@ use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres::Postgres;
 use tracing::{debug, info};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-use workers::{ArchiveQuery, BackgroundJob, Runner, archived_job_count, get_archived_jobs};
+use workers::{
+    ArchivalPolicy, ArchiveQuery, BackgroundJob, Runner, archived_job_count, get_archived_jobs,
+};
 
 #[derive(Debug, Serialize, Deserialize)]
 enum Notification {
@@ -131,7 +133,7 @@ async fn main() -> Result<()> {
             queue
                 .num_workers(2)
                 .poll_interval(Duration::from_millis(100))
-                .archive_completed_jobs(true) // Enable archiving for audit trail
+                .archive(ArchivalPolicy::All) // Enable archiving for audit trail
         })
         .shutdown_when_queue_empty();
 

--- a/examples/archive.rs
+++ b/examples/archive.rs
@@ -133,7 +133,7 @@ async fn main() -> Result<()> {
             queue
                 .num_workers(2)
                 .poll_interval(Duration::from_millis(100))
-                .archive(ArchivalPolicy::All) // Enable archiving for audit trail
+                .archive(ArchivalPolicy::Always) // Enable archiving for audit trail
         })
         .shutdown_when_queue_empty();
 

--- a/examples/archive_cleanup.rs
+++ b/examples/archive_cleanup.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<()> {
 
     let runner = Runner::new(pool.clone(), ())
         .register_job_type::<ReticulateSplineJob>()
-        .configure_default_queue(|queue| queue.archive(ArchivalPolicy::All))
+        .configure_default_queue(|queue| queue.archive(ArchivalPolicy::Always))
         .shutdown_when_queue_empty();
 
     ArchiveCleanerBuilder::new()

--- a/examples/archive_cleanup.rs
+++ b/examples/archive_cleanup.rs
@@ -21,8 +21,8 @@ use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres::Postgres;
 use tracing::info;
 use workers::{
-    ArchiveCleanerBuilder, BackgroundJob, CleanupConfiguration, CleanupPolicy, Runner,
-    archived_job_count,
+    ArchivalPolicy, ArchiveCleanerBuilder, BackgroundJob, CleanupConfiguration, CleanupPolicy,
+    Runner, archived_job_count,
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -77,7 +77,7 @@ async fn main() -> Result<()> {
 
     let runner = Runner::new(pool.clone(), ())
         .register_job_type::<ReticulateSplineJob>()
-        .configure_default_queue(|queue| queue.archive_completed_jobs(true))
+        .configure_default_queue(|queue| queue.archive(ArchivalPolicy::All))
         .shutdown_when_queue_empty();
 
     ArchiveCleanerBuilder::new()

--- a/src/cleaner.rs
+++ b/src/cleaner.rs
@@ -69,7 +69,7 @@ impl Default for CleanupConfiguration {
 }
 
 impl ArchiveCleanerBuilder {
-    /// Create a new, unconfigured, `ArchiveCleaner`
+    /// Create a new, unconfigured, `ArchiveCleanerBuilder`
     pub fn new() -> Self {
         Self {
             configurations: HashMap::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub use self::cleaner::{ArchiveCleanerBuilder, CleanupConfiguration, CleanupPoli
 /// Error type for job enqueueing operations.
 pub use self::errors::EnqueueError;
 /// The main runner that orchestrates job processing.
-pub use self::runner::Runner;
+pub use self::runner::{ArchivalPolicy, Runner};
 /// Database schema types.
 pub use self::schema::{ArchivedJob, BackgroundJob as BackgroundJobRecord};
 /// Archive functionality.

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,5 +1,6 @@
 use crate::job_registry::JobRegistry;
 use crate::runner::ArchivalPolicy;
+use crate::schema;
 use crate::storage;
 use crate::util::{try_to_extract_panic_info, with_sentry_transaction};
 use anyhow::anyhow;
@@ -33,6 +34,14 @@ impl<Context: Clone + Send + Sync + 'static> Worker<Context> {
         let jitter_millis = u64::try_from(self.jitter.as_millis()).unwrap_or(u64::MAX);
         let random_jitter = rand::rng().random_range(0..=jitter_millis);
         self.poll_interval + Duration::from_millis(random_jitter)
+    }
+
+    fn should_archive(&self, job: &schema::BackgroundJob, context: &Context) -> bool {
+        match &self.archive_completed_jobs {
+            ArchivalPolicy::Never => false,
+            ArchivalPolicy::Always => true,
+            ArchivalPolicy::If(predicate) => predicate(job, context),
+        }
     }
 
     /// Run background jobs forever, or until the queue is empty if `shutdown_when_queue_empty` is set.
@@ -95,11 +104,7 @@ impl<Context: Clone + Send + Sync + 'static> Worker<Context> {
 
         let job_id = job.id;
         debug!("Running job…");
-        let should_archive = match &self.archive_completed_jobs {
-            ArchivalPolicy::None => false,
-            ArchivalPolicy::All => true,
-            ArchivalPolicy::Predicate(pred_fn) => pred_fn(&context),
-        };
+        let should_archive = self.should_archive(&job, &context);
 
         let future = with_sentry_transaction(&job.job_type, async || {
             let run_task_fn = job_registry

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -16,7 +16,8 @@ use testcontainers::ContainerAsync;
 use testcontainers_modules::postgres::Postgres;
 use tokio::sync::Barrier;
 use workers::{
-    ArchiveQuery, BackgroundJob, Runner, archived_job_count, get_archived_jobs, setup_database,
+    ArchivalPolicy, ArchiveQuery, BackgroundJob, Runner, archived_job_count, get_archived_jobs,
+    setup_database,
 };
 
 /// Test utilities and common setup
@@ -457,7 +458,7 @@ async fn archive_functionality_works() -> anyhow::Result<()> {
     let runner = Runner::new(pool.clone(), ())
         .register_job_type::<TestJob>()
         .configure_queue("default", |queue| {
-            queue.num_workers(1).archive_completed_jobs(true) // Enable archiving
+            queue.num_workers(1).archive(ArchivalPolicy::All) // Enable archiving
         })
         .shutdown_when_queue_empty();
 
@@ -737,7 +738,7 @@ async fn archive_cleaner_removes_old_jobs() -> anyhow::Result<()> {
     let runner = Runner::new(pool.clone(), ())
         .register_job_type::<TestJob>()
         .configure_queue("default", |queue| {
-            queue.num_workers(1).archive_completed_jobs(true)
+            queue.num_workers(1).archive(ArchivalPolicy::All)
         })
         .shutdown_when_queue_empty();
 
@@ -791,7 +792,7 @@ async fn archive_cleaner_keeps_last_n_jobs() -> anyhow::Result<()> {
     let runner = Runner::new(pool.clone(), ())
         .register_job_type::<TestJob>()
         .configure_queue("default", |queue| {
-            queue.num_workers(1).archive_completed_jobs(true)
+            queue.num_workers(1).archive(ArchivalPolicy::All)
         })
         .shutdown_when_queue_empty();
 
@@ -850,7 +851,7 @@ async fn archive_cleaner_keeps_last_n_jobs_discards_old() -> anyhow::Result<()> 
     let runner = Runner::new(pool.clone(), ())
         .register_job_type::<TestJob>()
         .configure_queue("default", |queue| {
-            queue.num_workers(1).archive_completed_jobs(true)
+            queue.num_workers(1).archive(ArchivalPolicy::All)
         })
         .shutdown_when_queue_empty();
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -925,7 +925,10 @@ async fn archive_conditionally() -> anyhow::Result<()> {
     runner_handle.wait_for_shutdown().await;
 
     let archived_count = archived_job_count(&pool).await?;
-    assert_eq!(archived_count, 2, "Expected 2 successful jobs to be archived");
+    assert_eq!(
+        archived_count, 2,
+        "Expected 2 successful jobs to be archived"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
One thing I don't really like is that we have to compute whether the task should be archived before we even know if it ran successfully or not. The reason for this is that we need a reference to the job context that gets consumed as the job runs.

Potential fix would be to not give ownership of the context to the job run, instead opting for a reference (seen no cases where the context is used for anything not read-only).

Open to any suggestions on how to do this better, also need to figure out some non-contrived tests for the feature.

Solves #26 

