### PR TITLE
Make the API typesafe

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,17 +45,17 @@ impl BackgroundJob for SendEmailJob {
 ### Running the Worker
 
 ```rust,ignore
-use workers::Runner;
+use workers::{Runner, Queue};
 use std::time::Duration;
 
 let runner = Runner::new(connection_pool, app_context)
-    .configure_queue("emails", |queue| {
-        queue
-        .register::<SendEmailJob>()
-        .num_workers(2)
-        .poll_interval(Duration::from_secs(5))
-        .jitter(Duration::from_millis(500))
-    });
+    .add_queue(
+        Queue::named("emails")
+            .register::<SendEmailJob>()
+            .num_workers(2)
+            .poll_interval(Duration::from_secs(5))
+            .jitter(Duration::from_millis(500))
+    );
 
 let handle = runner.start();
 handle.wait_for_shutdown().await;
@@ -70,7 +70,7 @@ let job = SendEmailJob {
     body: "Thanks for signing up!".to_string(),
 };
 
-job.enqueue(&mut conn).await?;
+job.enqueue(&pool).await?;
 ```
 
 ## Configuration
@@ -163,26 +163,25 @@ cargo run --example batch
 By default, successfully completed jobs are deleted from the database. However, you can configure jobs to be archived instead, which moves them to an archive table for debugging, auditing, and potential replay.
 
 ```rust,ignore
-use workers::Runner;
-use runner::ArchivalPolicy;
+use workers::{Runner, Queue, ArchivalPolicy};
 
 let runner = Runner::new(pool, context)
-    .configure_queue("important", |queue| {
-        queue
-        .register::<MyJob>()
-        .archive(ArchivalPolicy::Always)  // Enable archiving
-    });
+    .add_queue(
+        Queue::named("important")
+            .register::<MyJob>()
+            .archive(ArchivalPolicy::Always)  // Enable archiving
+    );
 
 // We can get much more fine-grained control by using a predicate function:
 let runner = Runner::new(pool, context)
-    .configure_queue("fails_sometimes", |queue| {
-        queue
-        .register::<MyJob>()
-        .archive(ArchivalPolicy::If(|job, _ctx| {
-            // Archive only jobs that had to retry
-            job.retries > 0
-        }))
-    });
+    .add_queue(
+        Queue::named("fails_sometimes")
+            .register::<MyJob>()
+            .archive(ArchivalPolicy::If(|job, _ctx| {
+                // Archive only jobs that had to retry
+                job.retries > 0
+            }))
+    );
 ```
 
 To query archived jobs:
@@ -230,20 +229,35 @@ Each configured job type will start a background task with its own timer that pe
 
 ```rust,ignore
 use workers::{ArchiveCleanerBuilder, CleanupConfiguration, CleanupPolicy};
+use chrono::TimeDelta;
 use std::time::Duration;
 
-let cleaner = ArchiveCleanerBuilder::new()
+ArchiveCleanerBuilder::new()
     .configure::<MyJob>(CleanupConfiguration {
         cleanup_every: Duration::from_secs(60), // Run cleanup every 60 seconds
         policy: CleanupPolicy::MaxCount(1000),  // Keep only the latest 1000 archived jobs
     })
     .run(&pool);
 
-// Do whatever else...
+// Alternative policies:
+// - MaxAge: Remove jobs older than a specific duration
+ArchiveCleanerBuilder::new()
+    .configure::<MyJob>(CleanupConfiguration {
+        cleanup_every: Duration::from_secs(3600),
+        policy: CleanupPolicy::MaxAge(TimeDelta::days(30)),  // Remove jobs older than 30 days
+    })
+    .run(&pool);
 
-// You can manually stop the cleaner when needed:
-cleaner.stop();
-// or just let it fall out of scope and be aborted automatically.
+// - Retain: Keep at least N jobs, but remove older ones beyond a certain age
+ArchiveCleanerBuilder::new()
+    .configure::<MyJob>(CleanupConfiguration {
+        cleanup_every: Duration::from_secs(3600),
+        policy: CleanupPolicy::Retain {
+            max_age: TimeDelta::days(7),
+            keep_at_least: 100,  // Always keep at least 100 jobs, even if older than 7 days
+        },
+    })
+    .run(&pool);
 ```
 
 ## Database Setup
@@ -293,12 +307,16 @@ The workers poll the database for new jobs at regular intervals (configurable vi
 
 **Tuning Poll Intervals:**
 ```rust,ignore
-.configure_queue("low_priority", |queue| {
-    queue.poll_interval(Duration::from_secs(30))  // Less frequent polling
-})
-.configure_queue("urgent", |queue| {
-    queue.poll_interval(Duration::from_millis(100))  // More frequent polling
-})
+.add_queue(
+    Queue::named("low_priority")
+        .register::<LowPriorityJob>()
+        .poll_interval(Duration::from_secs(30))  // Less frequent polling
+)
+.add_queue(
+    Queue::named("urgent")
+        .register::<UrgentJob>()
+        .poll_interval(Duration::from_millis(100))  // More frequent polling
+)
 ```
 
 ### Why Use Polling Instead of LISTEN/NOTIFY?

--- a/examples/archive.rs
+++ b/examples/archive.rs
@@ -127,10 +127,10 @@ async fn main() -> Result<()> {
 
     // Create runner with archiving enabled for important jobs
     let runner = Runner::new(pool.clone(), ())
-        .register_job_type::<NotificationJob>()
-        .register_job_type::<PaymentJob>()
         .configure_queue("default", |queue| {
             queue
+                .register::<NotificationJob>()
+                .register::<PaymentJob>()
                 .num_workers(2)
                 .poll_interval(Duration::from_millis(100))
                 .archive(ArchivalPolicy::Always) // Enable archiving for audit trail

--- a/examples/archive.rs
+++ b/examples/archive.rs
@@ -129,7 +129,7 @@ async fn main() -> Result<()> {
     // Create runner with archiving enabled for important jobs
     let runner = Runner::new(pool.clone(), ())
         .add_queue(
-            Queue::new("notifications_payments")
+            Queue::named("notifications_payments")
                 .register::<NotificationJob>()
                 .register::<PaymentJob>()
                 .num_workers(2)

--- a/examples/archive.rs
+++ b/examples/archive.rs
@@ -20,7 +20,8 @@ use testcontainers_modules::postgres::Postgres;
 use tracing::{debug, info};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use workers::{
-    ArchivalPolicy, ArchiveQuery, BackgroundJob, Runner, archived_job_count, get_archived_jobs,
+    ArchivalPolicy, ArchiveQuery, BackgroundJob, Queue, Runner, archived_job_count,
+    get_archived_jobs,
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -127,14 +128,14 @@ async fn main() -> Result<()> {
 
     // Create runner with archiving enabled for important jobs
     let runner = Runner::new(pool.clone(), ())
-        .configure_queue("default", |queue| {
-            queue
+        .add_queue(
+            Queue::new("notifications_payments")
                 .register::<NotificationJob>()
                 .register::<PaymentJob>()
                 .num_workers(2)
                 .poll_interval(Duration::from_millis(100))
-                .archive(ArchivalPolicy::Always) // Enable archiving for audit trail
-        })
+                .archive(ArchivalPolicy::Always), // Enable archiving for audit trail
+        )
         .shutdown_when_queue_empty();
 
     // Enqueue some notification jobs

--- a/examples/archive_cleanup.rs
+++ b/examples/archive_cleanup.rs
@@ -76,8 +76,11 @@ async fn main() -> Result<()> {
     let (pool, _container) = setup_database().await?;
 
     let runner = Runner::new(pool.clone(), ())
-        .register_job_type::<ReticulateSplineJob>()
-        .configure_default_queue(|queue| queue.archive(ArchivalPolicy::Always))
+        .configure_queue("default", |queue| {
+            queue
+                .register::<ReticulateSplineJob>()
+                .archive(ArchivalPolicy::Always)
+        })
         .shutdown_when_queue_empty();
 
     ArchiveCleanerBuilder::new()

--- a/examples/archive_cleanup.rs
+++ b/examples/archive_cleanup.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<()> {
 
     let runner = Runner::new(pool.clone(), ())
         .add_queue(
-            Queue::new("spline_reticulator")
+            Queue::named("spline_reticulator")
                 .register::<ReticulateSplineJob>()
                 .archive(ArchivalPolicy::Always),
         )

--- a/examples/archive_cleanup.rs
+++ b/examples/archive_cleanup.rs
@@ -22,7 +22,7 @@ use testcontainers_modules::postgres::Postgres;
 use tracing::info;
 use workers::{
     ArchivalPolicy, ArchiveCleanerBuilder, BackgroundJob, CleanupConfiguration, CleanupPolicy,
-    Runner, archived_job_count,
+    Queue, Runner, archived_job_count,
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -76,11 +76,11 @@ async fn main() -> Result<()> {
     let (pool, _container) = setup_database().await?;
 
     let runner = Runner::new(pool.clone(), ())
-        .configure_queue("default", |queue| {
-            queue
+        .add_queue(
+            Queue::new("spline_reticulator")
                 .register::<ReticulateSplineJob>()
-                .archive(ArchivalPolicy::Always)
-        })
+                .archive(ArchivalPolicy::Always),
+        )
         .shutdown_when_queue_empty();
 
     ArchiveCleanerBuilder::new()

--- a/examples/stress_test/Cargo.lock
+++ b/examples/stress_test/Cargo.lock
@@ -1935,9 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa38b94e70820ff3f1f9db3c8b0aef053b667be130f618e615e0ff2492cbcc"
+checksum = "67600a47b5aa005cb701454d56a289135a80654eebf1c1d9f076c3817a249bb8"
 dependencies = [
  "rand 0.9.2",
  "sentry-types",
@@ -1948,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e477f4d4db08ddb4ab553717a8d3a511bc9e81dde0c808c680feacbb8105c412"
+checksum = "aa369b6dc823ba5bddd69d16620f19229eb5df865b9483cf4dabb608891bb9c2"
 dependencies = [
  "debugid",
  "hex",
@@ -3280,7 +3280,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "futures-util",
- "rand 0.8.5",
+ "rand 0.9.2",
  "sentry-core",
  "serde",
  "serde_json",

--- a/examples/stress_test/src/jobs.rs
+++ b/examples/stress_test/src/jobs.rs
@@ -24,12 +24,11 @@ pub struct CatchPokemonJob {
 impl BackgroundJob for CatchPokemonJob {
     const JOB_TYPE: &'static str = "catch_pokemon";
     const PRIORITY: i16 = 10; // Higher priority for catching!
-    const QUEUE: &'static str = "field_work";
     type Context = PokemonContext;
 
     async fn run(&self, ctx: Self::Context) -> Result<()> {
         let catch_time = Duration::from_millis(rand::thread_rng().gen_range(100..800));
-        
+
         info!(
             "🎯 Attempting to catch {} (Level {}) at {}...",
             self.pokemon_name, self.pokemon_level, self.location
@@ -48,17 +47,14 @@ impl BackgroundJob for CatchPokemonJob {
         };
 
         let roll = rand::thread_rng().gen_range(0.0..100.0);
-        
+
         if roll < success_rate {
             info!(
                 "✌️ Successfully caught {}! Added to Pokédex.",
                 self.pokemon_name
             );
         } else {
-            warn!(
-                "💨 {} broke free and escaped!",
-                self.pokemon_name
-            );
+            warn!("💨 {} broke free and escaped!", self.pokemon_name);
         }
 
         Ok(())
@@ -76,13 +72,12 @@ pub struct TrainPokemonJob {
 impl BackgroundJob for TrainPokemonJob {
     const JOB_TYPE: &'static str = "train_pokemon";
     const PRIORITY: i16 = 5;
-    const QUEUE: &'static str = "training";
     const DEDUPLICATED: bool = true; // Don't train the same Pokemon multiple times
     type Context = PokemonContext;
 
     async fn run(&self, _ctx: Self::Context) -> Result<()> {
         let training_time = Duration::from_millis(rand::thread_rng().gen_range(200..1500));
-        
+
         info!(
             "🏋️‍♂️ Starting {} training for {} (Level {})...",
             self.training_method, self.pokemon_name, self.current_level
@@ -113,25 +108,23 @@ pub struct HealPokemonJob {
 impl BackgroundJob for HealPokemonJob {
     const JOB_TYPE: &'static str = "heal_pokemon";
     const PRIORITY: i16 = 15; // Healing is urgent!
-    const QUEUE: &'static str = "pokemon_center";
     type Context = PokemonContext;
 
     async fn run(&self, _ctx: Self::Context) -> Result<()> {
         let healing_time = Duration::from_millis(
-            self.pokemon_names.len() as u64 * rand::thread_rng().gen_range(100..400)
+            self.pokemon_names.len() as u64 * rand::thread_rng().gen_range(100..400),
         );
-        
+
         info!(
             "🏥 Nurse Joy is healing {} Pokemon ({} injuries)...",
-            self.pokemon_names.len(), self.injury_severity
+            self.pokemon_names.len(),
+            self.injury_severity
         );
 
         // Simulate healing process
         sleep(healing_time).await;
 
-        info!(
-            "✨ All Pokemon have been fully healed! They're ready for adventure again."
-        );
+        info!("✨ All Pokemon have been fully healed! They're ready for adventure again.");
 
         Ok(())
     }
@@ -148,12 +141,11 @@ pub struct GymBattleJob {
 impl BackgroundJob for GymBattleJob {
     const JOB_TYPE: &'static str = "gym_battle";
     const PRIORITY: i16 = 20; // Gym battles are the highest priority!
-    const QUEUE: &'static str = "gym_battles";
     type Context = PokemonContext;
 
     async fn run(&self, ctx: Self::Context) -> Result<()> {
         let battle_time = Duration::from_millis(rand::thread_rng().gen_range(1000..3000));
-        
+
         info!(
             "💥️  Challenging {} ({} Gym) in {} City!",
             self.gym_leader, self.gym_type, self.city
@@ -192,12 +184,11 @@ pub struct ExploreAreaJob {
 impl BackgroundJob for ExploreAreaJob {
     const JOB_TYPE: &'static str = "explore_area";
     const PRIORITY: i16 = 3;
-    const QUEUE: &'static str = "exploration";
     type Context = PokemonContext;
 
     async fn run(&self, ctx: Self::Context) -> Result<()> {
         let exploration_time = Duration::from_millis(rand::thread_rng().gen_range(300..1200));
-        
+
         info!(
             "🗺️  {} is exploring {} ({} terrain)...",
             ctx.trainer_name, self.area_name, self.terrain_type
@@ -217,10 +208,7 @@ impl BackgroundJob for ExploreAreaJob {
 
         for _i in 0..discoveries {
             let pokemon = pokemon_types[rand::thread_rng().gen_range(0..pokemon_types.len())];
-            info!(
-                "👀 Discovered a wild {}!",
-                pokemon
-            );
+            info!("👀 Discovered a wild {}!", pokemon);
         }
 
         info!(

--- a/examples/stress_test/src/main.rs
+++ b/examples/stress_test/src/main.rs
@@ -12,7 +12,7 @@ use testcontainers_modules::postgres::Postgres;
 use tokio::time::{Instant, sleep};
 use tracing::{info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-use workers::{BackgroundJob, Runner};
+use workers::{BackgroundJob, Queue, Runner};
 
 /// Pokemon Stress Test - Demonstrates high-throughput job processing
 #[derive(Parser)]
@@ -308,39 +308,39 @@ async fn main() -> Result<()> {
     // Setup worker queues with different configurations
     info!("⚙️  Setting up worker queues...");
     let runner = Runner::new(pool.clone(), trainer_context.clone())
-        .register_job_type::<CatchPokemonJob>()
-        .register_job_type::<TrainPokemonJob>()
-        .register_job_type::<HealPokemonJob>()
-        .register_job_type::<GymBattleJob>()
-        .register_job_type::<ExploreAreaJob>()
-        .shutdown_when_queue_empty() // Stop when all jobs are processed
-        .configure_queue("field_work", |queue| {
-            queue
+        .add_queue(
+            Queue::named("field_work")
+                .register::<CatchPokemonJob>()
                 .num_workers(args.workers)
                 .poll_interval(Duration::from_millis(50))
-                .jitter(Duration::from_millis(25))
-        })
-        .configure_queue("training", |queue| {
-            queue
+                .jitter(Duration::from_millis(25)),
+        )
+        .add_queue(
+            Queue::named("training")
+                .register::<TrainPokemonJob>()
                 .num_workers(args.workers / 2)
                 .poll_interval(Duration::from_millis(100))
-                .jitter(Duration::from_millis(50))
-        })
-        .configure_queue("pokemon_center", |queue| {
-            queue
+                .jitter(Duration::from_millis(50)),
+        )
+        .add_queue(
+            Queue::named("pokemon_center")
+                .register::<HealPokemonJob>()
                 .num_workers(args.workers / 4)
-                .poll_interval(Duration::from_millis(100))
-        })
-        .configure_queue("gym_battles", |queue| {
-            queue
+                .poll_interval(Duration::from_millis(100)),
+        )
+        .add_queue(
+            Queue::named("gym_battles")
+                .register::<GymBattleJob>()
                 .num_workers(2)
-                .poll_interval(Duration::from_millis(200))
-        })
-        .configure_queue("exploration", |queue| {
-            queue
+                .poll_interval(Duration::from_millis(200)),
+        )
+        .add_queue(
+            Queue::named("exploration")
+                .register::<ExploreAreaJob>()
                 .num_workers(args.workers)
-                .poll_interval(Duration::from_millis(150))
-        });
+                .poll_interval(Duration::from_millis(150)),
+        )
+        .shutdown_when_queue_empty(); // Stop when all jobs are processed
 
     info!("✅ Worker configuration complete:");
     info!(

--- a/src/background_job.rs
+++ b/src/background_job.rs
@@ -8,9 +8,6 @@ use sqlx::PgPool;
 use std::future::Future;
 use tracing::instrument;
 
-/// The default queue name used when no specific queue is specified.
-pub const DEFAULT_QUEUE: &str = "default";
-
 /// Trait for defining background jobs that can be enqueued and executed asynchronously.
 pub trait BackgroundJob: Serialize + DeserializeOwned + Send + Sync + 'static {
     /// Unique name of the task.
@@ -28,9 +25,6 @@ pub trait BackgroundJob: Serialize + DeserializeOwned + Send + Sync + 'static {
     /// If true, the job will not be enqueued if there is already an unstarted
     /// job with the same data.
     const DEDUPLICATED: bool = false;
-
-    /// Job queue where this job will be executed.
-    const QUEUE: &'static str = DEFAULT_QUEUE;
 
     /// The application data provided to this job at runtime.
     type Context: Clone + Send + 'static;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,6 @@ mod worker;
 
 /// The main trait for defining background jobs.
 pub use self::background_job::BackgroundJob;
-/// The default queue name used when no specific queue is specified.
-pub use self::background_job::DEFAULT_QUEUE;
 /// The archive cleaner for purging archived jobs.
 pub use self::cleaner::{ArchiveCleanerBuilder, CleanupConfiguration, CleanupPolicy};
 /// Error type for job enqueueing operations.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub use self::cleaner::{ArchiveCleanerBuilder, CleanupConfiguration, CleanupPoli
 /// Error type for job enqueueing operations.
 pub use self::errors::EnqueueError;
 /// The main runner that orchestrates job processing.
-pub use self::runner::{ArchivalPolicy, Runner};
+pub use self::runner::{ArchivalPolicy, Queue, Runner};
 /// Database schema types.
 pub use self::schema::{ArchivedJob, BackgroundJob as BackgroundJobRecord};
 /// Archive functionality.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -60,10 +60,10 @@ impl<Context: Clone + Send + Sync + 'static, State> Runner<Context, State> {
     pub fn configure_queue(
         mut self,
         queue_name: &str,
-        config_fn: impl FnOnce(Queue<Context>) -> Queue<Context, Configured>,
+        config_fn: impl FnOnce(&mut Queue<Context>) -> Queue<Context, Configured>,
     ) -> Runner<Context, Configured> {
         self.queues
-            .insert(queue_name.into(), config_fn(Queue::default()));
+            .insert(queue_name.into(), config_fn(&mut Queue::default()));
 
         Runner {
             connection_pool: self.connection_pool,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,4 +1,3 @@
-use crate::background_job::DEFAULT_QUEUE;
 use crate::job_registry::JobRegistry;
 use crate::worker::Worker;
 use crate::{BackgroundJob, schema, storage};
@@ -6,6 +5,7 @@ use anyhow::anyhow;
 use futures_util::future::join_all;
 use sqlx::PgPool;
 use std::collections::HashMap;
+use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::task::JoinHandle;
@@ -14,15 +14,25 @@ use tracing::{Instrument, info, info_span, warn};
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(1);
 const DEFAULT_JITTER: Duration = Duration::from_millis(100);
 
+/// Marker type for a configured runner
+#[derive(Debug)]
+pub struct Configured;
+/// Marker type for an unconfigured runner
+#[derive(Debug)]
+pub struct Unconfigured;
+
 /// The core runner responsible for locking and running jobs
-pub struct Runner<Context> {
+pub struct Runner<Context: Clone + Send + Sync + 'static, State = Unconfigured> {
     connection_pool: PgPool,
-    queues: HashMap<String, Queue<Context>>,
+    queues: HashMap<String, Queue<Context, Configured>>,
     context: Context,
     shutdown_when_queue_empty: bool,
+    _state: PhantomData<State>,
 }
 
-impl<Context: std::fmt::Debug> std::fmt::Debug for Runner<Context> {
+impl<Context: std::fmt::Debug + Clone + Sync + Send, State: std::fmt::Debug> std::fmt::Debug
+    for Runner<Context, State>
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Runner")
             .field("queues", &self.queues.keys().collect::<Vec<_>>())
@@ -34,38 +44,34 @@ impl<Context: std::fmt::Debug> std::fmt::Debug for Runner<Context> {
 
 impl<Context: Clone + Send + Sync + 'static> Runner<Context> {
     /// Create a new runner with the given connection pool and context.
-    pub fn new(connection_pool: PgPool, context: Context) -> Self {
+    pub fn new(connection_pool: PgPool, context: Context) -> Runner<Context, Unconfigured> {
         Self {
             connection_pool,
             queues: HashMap::new(),
             context,
             shutdown_when_queue_empty: false,
+            _state: PhantomData,
         }
     }
+}
 
-    /// Register a new job type for this job runner.
-    pub fn register_job_type<J: BackgroundJob<Context = Context>>(mut self) -> Self {
-        let queue = self.queues.entry(J::QUEUE.into()).or_default();
-        queue.job_registry.register::<J>();
-        self
-    }
+impl<Context: Clone + Send + Sync + 'static, State> Runner<Context, State> {
+    /// Configure a queue
+    pub fn configure_queue(
+        mut self,
+        queue_name: &str,
+        config_fn: impl FnOnce(Queue<Context>) -> Queue<Context, Configured>,
+    ) -> Runner<Context, Configured> {
+        self.queues
+            .insert(queue_name.into(), config_fn(Queue::default()));
 
-    /// Adjust the configuration of the [`DEFAULT_QUEUE`] queue.
-    pub fn configure_default_queue<F>(self, f: F) -> Self
-    where
-        F: FnOnce(&mut Queue<Context>) -> &Queue<Context>,
-    {
-        self.configure_queue(DEFAULT_QUEUE, f)
-    }
-
-    /// Adjust the configuration of a queue. If the queue does not exist,
-    /// it will be created.
-    pub fn configure_queue<F>(mut self, name: &str, f: F) -> Self
-    where
-        F: FnOnce(&mut Queue<Context>) -> &Queue<Context>,
-    {
-        f(self.queues.entry(name.into()).or_default());
-        self
+        Runner {
+            connection_pool: self.connection_pool,
+            queues: self.queues,
+            context: self.context,
+            shutdown_when_queue_empty: self.shutdown_when_queue_empty,
+            _state: PhantomData,
+        }
     }
 
     /// Set the runner to shut down when the background job queue is empty.
@@ -74,6 +80,21 @@ impl<Context: Clone + Send + Sync + 'static> Runner<Context> {
         self
     }
 
+    /// Check if any jobs in the queue have failed.
+    ///
+    /// This function is intended for use in tests and will return an error if
+    /// any jobs have failed.
+    pub async fn check_for_failed_jobs(&self) -> anyhow::Result<()> {
+        let failed_jobs = storage::failed_job_count(&self.connection_pool).await?;
+        if failed_jobs == 0 {
+            Ok(())
+        } else {
+            Err(anyhow!("{failed_jobs} jobs failed"))
+        }
+    }
+}
+
+impl<Context: Clone + Send + Sync + 'static> Runner<Context, Configured> {
     /// Start the background workers.
     ///
     /// This returns a `RunningRunner` which can be used to wait for the workers to shutdown.
@@ -102,19 +123,6 @@ impl<Context: Clone + Send + Sync + 'static> Runner<Context> {
         }
 
         RunHandle { handles }
-    }
-
-    /// Check if any jobs in the queue have failed.
-    ///
-    /// This function is intended for use in tests and will return an error if
-    /// any jobs have failed.
-    pub async fn check_for_failed_jobs(&self) -> anyhow::Result<()> {
-        let failed_jobs = storage::failed_job_count(&self.connection_pool).await?;
-        if failed_jobs == 0 {
-            Ok(())
-        } else {
-            Err(anyhow!("{failed_jobs} jobs failed"))
-        }
     }
 }
 
@@ -159,35 +167,37 @@ impl<Context> std::fmt::Debug for ArchivalPolicy<Context> {
 
 /// Configuration and state for a job queue
 #[derive(Debug)]
-pub struct Queue<Context> {
+pub struct Queue<Context: Clone + Send + Sync + 'static, State = Unconfigured> {
     job_registry: JobRegistry<Context>,
     num_workers: usize,
     poll_interval: Duration,
     jitter: Duration,
     archive_completed_jobs: ArchivalPolicy<Context>,
+    _state: PhantomData<State>,
 }
 
-impl<Context> Default for Queue<Context> {
+impl<Context: Clone + Send + Sync + 'static> Default for Queue<Context, Unconfigured> {
     fn default() -> Self {
-        Self {
+        Queue {
             job_registry: JobRegistry::default(),
             num_workers: 1,
             poll_interval: DEFAULT_POLL_INTERVAL,
             jitter: DEFAULT_JITTER,
             archive_completed_jobs: ArchivalPolicy::default(),
+            _state: PhantomData,
         }
     }
 }
 
-impl<Context> Queue<Context> {
+impl<Context: Clone + Send + Sync + 'static, State> Queue<Context, State> {
     /// Set the number of worker threads for this queue.
-    pub fn num_workers(&mut self, num_workers: usize) -> &mut Self {
+    pub fn num_workers(mut self, num_workers: usize) -> Self {
         self.num_workers = num_workers;
         self
     }
 
     /// Set how often workers poll for new jobs.
-    pub fn poll_interval(&mut self, poll_interval: Duration) -> &mut Self {
+    pub fn poll_interval(mut self, poll_interval: Duration) -> Self {
         self.poll_interval = poll_interval;
         self
     }
@@ -197,14 +207,27 @@ impl<Context> Queue<Context> {
     /// Jitter helps reduce thundering herd effects when multiple workers
     /// are polling for jobs simultaneously. The actual jitter applied will
     /// be a random value between 0 and the specified duration.
-    pub fn jitter(&mut self, jitter: Duration) -> &mut Self {
+    pub fn jitter(mut self, jitter: Duration) -> Self {
         self.jitter = jitter;
         self
     }
 
     /// Set whether completed jobs should be archived instead of deleted.
-    pub fn archive(&mut self, policy: ArchivalPolicy<Context>) -> &mut Self {
+    pub fn archive(mut self, policy: ArchivalPolicy<Context>) -> Self {
         self.archive_completed_jobs = policy;
         self
+    }
+
+    /// Configure a job to run as part of this queue.
+    pub fn register<J: BackgroundJob<Context = Context>>(&mut self) -> Queue<Context, Configured> {
+        self.job_registry.register::<J>();
+        Queue {
+            job_registry: self.job_registry.clone(),
+            num_workers: self.num_workers,
+            poll_interval: self.poll_interval,
+            jitter: self.jitter,
+            archive_completed_jobs: self.archive_completed_jobs.clone(),
+            _state: PhantomData,
+        }
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3,7 +3,6 @@ use crate::worker::Worker;
 use crate::{BackgroundJob, schema};
 use futures_util::future::join_all;
 use sqlx::PgPool;
-use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
@@ -25,7 +24,7 @@ pub struct Unconfigured;
 /// The core runner responsible for locking and running jobs
 pub struct Runner<Context: Clone + Send + Sync + 'static, State = Unconfigured> {
     connection_pool: PgPool,
-    queues: HashMap<String, Queue<Context, Configured>>,
+    queues: Vec<Queue<Context, Configured>>,
     context: Context,
     shutdown_when_queue_empty: bool,
     _state: PhantomData<State>,
@@ -36,7 +35,15 @@ impl<Context: std::fmt::Debug + Clone + Sync + Send, State: std::fmt::Debug> std
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Runner")
-            .field("queues", &self.queues.keys().collect::<Vec<_>>())
+            .field(
+                "queues",
+                &self
+                    .queues
+                    .iter()
+                    .enumerate()
+                    .map(|(qid, q)| q.name.clone().unwrap_or_else(|| qid.to_string()))
+                    .collect::<Vec<_>>(),
+            )
             .field("context", &self.context)
             .field("shutdown_when_queue_empty", &self.shutdown_when_queue_empty)
             .finish()
@@ -48,7 +55,7 @@ impl<Context: Clone + Send + Sync + 'static> Runner<Context> {
     pub fn new(connection_pool: PgPool, context: Context) -> Self {
         Self {
             connection_pool,
-            queues: HashMap::new(),
+            queues: Vec::new(),
             context,
             shutdown_when_queue_empty: false,
             _state: PhantomData,
@@ -57,15 +64,9 @@ impl<Context: Clone + Send + Sync + 'static> Runner<Context> {
 }
 
 impl<Context: Clone + Send + Sync + 'static, State> Runner<Context, State> {
-    /// Configure a queue
-    pub fn configure_queue(
-        mut self,
-        queue_name: &str,
-        config_fn: impl FnOnce(Queue<Context>) -> Queue<Context, Configured>,
-    ) -> Runner<Context, Configured> {
-        self.queues
-            .insert(queue_name.into(), config_fn(Queue::default()));
-
+    /// TODO: Tentative API - replace `configure_queue` if accepted
+    pub fn add_queue(mut self, queue: Queue<Context, Configured>) -> Runner<Context, Configured> {
+        self.queues.push(queue);
         Runner {
             connection_pool: self.connection_pool,
             queues: self.queues,
@@ -88,9 +89,15 @@ impl<Context: Clone + Send + Sync + 'static> Runner<Context, Configured> {
     /// This returns a `RunningRunner` which can be used to wait for the workers to shutdown.
     pub fn start(&self) -> RunHandle {
         let mut handles = Vec::new();
-        for (queue_name, queue) in &self.queues {
-            for i in 1..=queue.num_workers {
-                let name = format!("background-worker-{queue_name}-{i}");
+        for (queue_index, queue) in self.queues.iter().enumerate() {
+            for i in 0..queue.num_workers {
+                let name = format!(
+                    "queue-{queue_name}-worker-{i}",
+                    queue_name = queue
+                        .name
+                        .clone()
+                        .unwrap_or_else(|| queue_index.to_string()),
+                );
                 info!(worker.name = %name, "Starting worker…");
 
                 let worker = Worker {
@@ -156,6 +163,8 @@ impl<Context> std::fmt::Debug for ArchivalPolicy<Context> {
 /// Configuration and state for a job queue
 #[derive(Debug)]
 pub struct Queue<Context: Clone + Send + Sync + 'static, State = Unconfigured> {
+    /// Queue name can be set for clearer log output
+    pub name: Option<String>,
     job_registry: JobRegistry<Context>,
     num_workers: usize,
     poll_interval: Duration,
@@ -167,12 +176,25 @@ pub struct Queue<Context: Clone + Send + Sync + 'static, State = Unconfigured> {
 impl<Context: Clone + Send + Sync + 'static> Default for Queue<Context, Unconfigured> {
     fn default() -> Self {
         Self {
+            name: None,
             job_registry: JobRegistry::default(),
             num_workers: 1,
             poll_interval: DEFAULT_POLL_INTERVAL,
             jitter: DEFAULT_JITTER,
             archive_completed_jobs: ArchivalPolicy::default(),
             _state: PhantomData,
+        }
+    }
+}
+impl<Context: Clone + Send + Sync + 'static> Queue<Context> {
+    /// Make a new, named queue
+    /// The name is used only in logging.
+    ///
+    /// Use `Queue::default()` if you don't need a name.
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: Some(name.to_string()),
+            ..Default::default()
         }
     }
 }
@@ -210,6 +232,7 @@ impl<Context: Clone + Send + Sync + 'static, State> Queue<Context, State> {
     pub fn register<J: BackgroundJob<Context = Context>>(mut self) -> Queue<Context, Configured> {
         self.job_registry.register::<J>();
         Queue {
+            name: self.name,
             job_registry: self.job_registry,
             num_workers: self.num_workers,
             poll_interval: self.poll_interval,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -35,15 +35,7 @@ impl<Context: std::fmt::Debug + Clone + Sync + Send, State: std::fmt::Debug> std
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Runner")
-            .field(
-                "queues",
-                &self
-                    .queues
-                    .iter()
-                    .enumerate()
-                    .map(|(qid, q)| q.name.clone().unwrap_or_else(|| qid.to_string()))
-                    .collect::<Vec<_>>(),
-            )
+            .field("queues", &self.collect_queue_names())
             .field("context", &self.context)
             .field("shutdown_when_queue_empty", &self.shutdown_when_queue_empty)
             .finish()
@@ -64,7 +56,7 @@ impl<Context: Clone + Send + Sync + 'static> Runner<Context> {
 }
 
 impl<Context: Clone + Send + Sync + 'static, State> Runner<Context, State> {
-    /// TODO: Tentative API - replace `configure_queue` if accepted
+    /// Add a configured queue to the runner.
     pub fn add_queue(mut self, queue: Queue<Context, Configured>) -> Runner<Context, Configured> {
         self.queues.push(queue);
         Runner {
@@ -81,6 +73,15 @@ impl<Context: Clone + Send + Sync + 'static, State> Runner<Context, State> {
         self.shutdown_when_queue_empty = true;
         self
     }
+
+    /// Collect the names of all queues in the runner.
+    pub fn collect_queue_names(&self) -> Vec<String> {
+        self.queues
+            .iter()
+            .enumerate()
+            .map(|(qid, q)| q.name.clone().unwrap_or_else(|| qid.to_string()))
+            .collect::<Vec<_>>()
+    }
 }
 
 impl<Context: Clone + Send + Sync + 'static> Runner<Context, Configured> {
@@ -91,6 +92,7 @@ impl<Context: Clone + Send + Sync + 'static> Runner<Context, Configured> {
         let mut handles = Vec::new();
         for (queue_index, queue) in self.queues.iter().enumerate() {
             for i in 0..queue.num_workers {
+                // Did not go for a method on the queue for the name because it would require passing in the index as a parameter, which would be ugly.
                 let name = format!(
                     "queue-{queue_name}-worker-{i}",
                     queue_name = queue
@@ -191,7 +193,7 @@ impl<Context: Clone + Send + Sync + 'static> Queue<Context> {
     /// The name is used only in logging.
     ///
     /// Use `Queue::default()` if you don't need a name.
-    pub fn new(name: &str) -> Self {
+    pub fn named(name: &str) -> Self {
         Self {
             name: Some(name.to_string()),
             ..Default::default()

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -15,13 +15,6 @@ pub enum ArchiveQuery {
     },
 }
 
-/// The number of jobs that have failed at least once
-pub(crate) async fn failed_job_count(pool: &PgPool) -> Result<i64, sqlx::Error> {
-    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM background_jobs WHERE retries > 0")
-        .fetch_one(pool)
-        .await
-}
-
 /// Finds the next job that is unlocked, and ready to be retried.
 pub(crate) async fn find_next_unlocked_job_tx(
     tx: &mut Transaction<'_, Postgres>,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -906,12 +906,13 @@ async fn archive_conditionally() -> anyhow::Result<()> {
 
     // Configure runner with predicate-based archiving
     let runner = Runner::new(pool.clone(), ())
-        .register_job_type::<TestJob>()
-        .configure_queue("default", |queue| {
-            queue.archive(ArchivalPolicy::If(|job, _ctx| {
-                // Archive only even-numbered jobs, for a 50% sample
-                job.id % 2 == 0
-            }))
+        .configure_queue("default", |mut queue| {
+            queue
+                .register::<TestJob>()
+                .archive(ArchivalPolicy::If(|job, _ctx| {
+                    // Archive only even-numbered jobs, for a 50% sample
+                    job.id % 2 == 0
+                }))
         })
         .shutdown_when_queue_empty();
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -906,7 +906,7 @@ async fn archive_conditionally() -> anyhow::Result<()> {
 
     // Configure runner with predicate-based archiving
     let runner = Runner::new(pool.clone(), ())
-        .configure_queue("default", |mut queue| {
+        .configure_queue("default", |queue| {
             queue
                 .register::<TestJob>()
                 .archive(ArchivalPolicy::If(|job, _ctx| {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -68,9 +68,7 @@ mod test_utils {
         pool: PgPool,
         context: Context,
     ) -> Runner<Context> {
-        Runner::new(pool, context)
-            .configure_default_queue(|queue| queue.num_workers(2))
-            .shutdown_when_queue_empty()
+        Runner::new(pool, context).shutdown_when_queue_empty()
     }
 }
 
@@ -161,7 +159,7 @@ async fn jobs_are_locked_when_fetched() -> anyhow::Result<()> {
     let (pool, _container) = test_utils::setup_test_db().await?;
 
     let runner = test_utils::create_test_runner(pool.clone(), test_context.clone())
-        .register_job_type::<TestJob>();
+        .configure_queue("default", |queue| queue.register::<TestJob>());
 
     let job_id = assert_some!(TestJob.enqueue(&pool).await?);
 
@@ -205,7 +203,8 @@ async fn jobs_are_deleted_when_successfully_run() -> anyhow::Result<()> {
 
     let (pool, _container) = test_utils::setup_test_db().await?;
 
-    let runner = test_utils::create_test_runner(pool.clone(), ()).register_job_type::<TestJob>();
+    let runner = test_utils::create_test_runner(pool.clone(), ())
+        .configure_queue("default", |queue| queue.register::<TestJob>());
 
     assert_eq!(remaining_jobs(&pool).await?, 0);
 
@@ -246,7 +245,7 @@ async fn failed_jobs_do_not_release_lock_before_updating_retry_time() -> anyhow:
     let (pool, _container) = test_utils::setup_test_db().await?;
 
     let runner = test_utils::create_test_runner(pool.clone(), test_context.clone())
-        .register_job_type::<TestJob>();
+        .configure_queue("default", |queue| queue.register::<TestJob>());
 
     TestJob.enqueue(&pool).await?;
 
@@ -291,7 +290,8 @@ async fn panicking_in_jobs_updates_retry_counter() -> anyhow::Result<()> {
 
     let (pool, _container) = test_utils::setup_test_db().await?;
 
-    let runner = test_utils::create_test_runner(pool.clone(), ()).register_job_type::<TestJob>();
+    let runner = test_utils::create_test_runner(pool.clone(), ())
+        .configure_queue("default", |queue| queue.register::<TestJob>());
 
     let job_id = assert_some!(TestJob.enqueue(&pool).await?);
 
@@ -354,7 +354,7 @@ async fn jobs_can_be_deduplicated() -> anyhow::Result<()> {
     let (pool, _container) = test_utils::setup_test_db().await?;
 
     let runner = Runner::new(pool.clone(), test_context.clone())
-        .register_job_type::<TestJob>()
+        .configure_queue("default", |queue| queue.register::<TestJob>())
         .shutdown_when_queue_empty();
 
     // Enqueue first job
@@ -411,9 +411,9 @@ async fn jitter_configuration_affects_polling() -> anyhow::Result<()> {
 
     // Test that jitter configuration is accepted and compiles
     let runner = Runner::new(pool.clone(), ())
-        .register_job_type::<TestJob>()
         .configure_queue("default", |queue| {
             queue
+                .register::<TestJob>()
                 .num_workers(1)
                 .poll_interval(Duration::from_millis(100))
                 .jitter(Duration::from_millis(50)) // Add up to 50ms jitter
@@ -456,9 +456,11 @@ async fn archive_functionality_works() -> anyhow::Result<()> {
 
     // Configure runner with archiving enabled
     let runner = Runner::new(pool.clone(), ())
-        .register_job_type::<TestJob>()
         .configure_queue("default", |queue| {
-            queue.num_workers(1).archive(ArchivalPolicy::Always) // Enable archiving
+            queue
+                .register::<TestJob>()
+                .num_workers(1)
+                .archive(ArchivalPolicy::Always) // Enable archiving
         })
         .shutdown_when_queue_empty();
 
@@ -736,9 +738,11 @@ async fn archive_cleaner_removes_old_jobs() -> anyhow::Result<()> {
 
     // Configure runner with archiving enabled
     let runner = Runner::new(pool.clone(), ())
-        .register_job_type::<TestJob>()
         .configure_queue("default", |queue| {
-            queue.num_workers(1).archive(ArchivalPolicy::Always)
+            queue
+                .register::<TestJob>()
+                .num_workers(1)
+                .archive(ArchivalPolicy::Always)
         })
         .shutdown_when_queue_empty();
 
@@ -790,9 +794,11 @@ async fn archive_cleaner_keeps_last_n_jobs() -> anyhow::Result<()> {
 
     // Configure runner with archiving enabled
     let runner = Runner::new(pool.clone(), ())
-        .register_job_type::<TestJob>()
         .configure_queue("default", |queue| {
-            queue.num_workers(1).archive(ArchivalPolicy::Always)
+            queue
+                .register::<TestJob>()
+                .num_workers(1)
+                .archive(ArchivalPolicy::Always)
         })
         .shutdown_when_queue_empty();
 
@@ -849,9 +855,11 @@ async fn archive_cleaner_keeps_last_n_jobs_discards_old() -> anyhow::Result<()> 
 
     // Configure runner with archiving enabled
     let runner = Runner::new(pool.clone(), ())
-        .register_job_type::<TestJob>()
         .configure_queue("default", |queue| {
-            queue.num_workers(1).archive(ArchivalPolicy::Always)
+            queue
+                .register::<TestJob>()
+                .num_workers(1)
+                .archive(ArchivalPolicy::Always)
         })
         .shutdown_when_queue_empty();
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -941,29 +941,3 @@ async fn archive_conditionally() -> anyhow::Result<()> {
 
     Ok(())
 }
-
-#[tokio::test]
-async fn show_potential_api() -> anyhow::Result<()> {
-    #[derive(Serialize, Deserialize)]
-    struct SomeJob;
-
-    impl BackgroundJob for SomeJob {
-        const JOB_TYPE: &'static str = "test_archive_conditionally";
-        type Context = ();
-
-        async fn run(&self, _ctx: Self::Context) -> anyhow::Result<()> {
-            Ok(())
-        }
-    }
-
-    let (pool, _container) = test_utils::setup_test_db().await?;
-
-    let _runner = Runner::new(pool, ())
-        .add_queue(
-            Queue::default()
-                .register::<SomeJob>()
-                .archive(ArchivalPolicy::If(|job, _ctx| job.id % 2 == 0)),
-        )
-        .shutdown_when_queue_empty();
-    Ok(())
-}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -159,7 +159,7 @@ async fn jobs_are_locked_when_fetched() -> anyhow::Result<()> {
     let (pool, _container) = test_utils::setup_test_db().await?;
 
     let runner = test_utils::create_test_runner(pool.clone(), test_context.clone())
-        .configure_queue("default", Queue::register::<TestJob>);
+        .add_queue(Queue::default().register::<TestJob>());
 
     let job_id = assert_some!(TestJob.enqueue(&pool).await?);
 
@@ -204,7 +204,7 @@ async fn jobs_are_deleted_when_successfully_run() -> anyhow::Result<()> {
     let (pool, _container) = test_utils::setup_test_db().await?;
 
     let runner = test_utils::create_test_runner(pool.clone(), ())
-        .configure_queue("default", Queue::register::<TestJob>);
+        .add_queue(Queue::default().register::<TestJob>());
 
     assert_eq!(remaining_jobs(&pool).await?, 0);
 
@@ -245,7 +245,7 @@ async fn failed_jobs_do_not_release_lock_before_updating_retry_time() -> anyhow:
     let (pool, _container) = test_utils::setup_test_db().await?;
 
     let runner = test_utils::create_test_runner(pool.clone(), test_context.clone())
-        .configure_queue("default", Queue::register::<TestJob>);
+        .add_queue(Queue::default().register::<TestJob>());
 
     TestJob.enqueue(&pool).await?;
 
@@ -291,7 +291,7 @@ async fn panicking_in_jobs_updates_retry_counter() -> anyhow::Result<()> {
     let (pool, _container) = test_utils::setup_test_db().await?;
 
     let runner = test_utils::create_test_runner(pool.clone(), ())
-        .configure_queue("default", Queue::register::<TestJob>);
+        .add_queue(Queue::default().register::<TestJob>());
 
     let job_id = assert_some!(TestJob.enqueue(&pool).await?);
 
@@ -354,7 +354,7 @@ async fn jobs_can_be_deduplicated() -> anyhow::Result<()> {
     let (pool, _container) = test_utils::setup_test_db().await?;
 
     let runner = Runner::new(pool.clone(), test_context.clone())
-        .configure_queue("default", Queue::register::<TestJob>)
+        .add_queue(Queue::default().register::<TestJob>())
         .shutdown_when_queue_empty();
 
     // Enqueue first job
@@ -411,13 +411,13 @@ async fn jitter_configuration_affects_polling() -> anyhow::Result<()> {
 
     // Test that jitter configuration is accepted and compiles
     let runner = Runner::new(pool.clone(), ())
-        .configure_queue("default", |queue| {
-            queue
+        .add_queue(
+            Queue::default()
                 .register::<TestJob>()
                 .num_workers(1)
                 .poll_interval(Duration::from_millis(100))
-                .jitter(Duration::from_millis(50)) // Add up to 50ms jitter
-        })
+                .jitter(Duration::from_millis(50)), // Add up to 50ms jitter
+        )
         .shutdown_when_queue_empty();
 
     // No jobs in queue, so the worker will immediately shut down
@@ -456,12 +456,12 @@ async fn archive_functionality_works() -> anyhow::Result<()> {
 
     // Configure runner with archiving enabled
     let runner = Runner::new(pool.clone(), ())
-        .configure_queue("default", |queue| {
-            queue
+        .add_queue(
+            Queue::default()
                 .register::<TestJob>()
                 .num_workers(1)
-                .archive(ArchivalPolicy::Always) // Enable archiving
-        })
+                .archive(ArchivalPolicy::Always), // Enable archiving
+        )
         .shutdown_when_queue_empty();
 
     // Enqueue a test job
@@ -738,12 +738,12 @@ async fn archive_cleaner_removes_old_jobs() -> anyhow::Result<()> {
 
     // Configure runner with archiving enabled
     let runner = Runner::new(pool.clone(), ())
-        .configure_queue("default", |queue| {
-            queue
+        .add_queue(
+            Queue::default()
                 .register::<TestJob>()
                 .num_workers(1)
-                .archive(ArchivalPolicy::Always)
-        })
+                .archive(ArchivalPolicy::Always),
+        )
         .shutdown_when_queue_empty();
 
     // Enqueue and process a test job to create an archived job
@@ -794,12 +794,12 @@ async fn archive_cleaner_keeps_last_n_jobs() -> anyhow::Result<()> {
 
     // Configure runner with archiving enabled
     let runner = Runner::new(pool.clone(), ())
-        .configure_queue("default", |queue| {
-            queue
+        .add_queue(
+            Queue::default()
                 .register::<TestJob>()
                 .num_workers(1)
-                .archive(ArchivalPolicy::Always)
-        })
+                .archive(ArchivalPolicy::Always),
+        )
         .shutdown_when_queue_empty();
 
     // Enqueue and process multiple test jobs to create archived jobs
@@ -855,12 +855,12 @@ async fn archive_cleaner_keeps_last_n_jobs_discards_old() -> anyhow::Result<()> 
 
     // Configure runner with archiving enabled
     let runner = Runner::new(pool.clone(), ())
-        .configure_queue("default", |queue| {
-            queue
+        .add_queue(
+            Queue::default()
                 .register::<TestJob>()
                 .num_workers(1)
-                .archive(ArchivalPolicy::Always)
-        })
+                .archive(ArchivalPolicy::Always),
+        )
         .shutdown_when_queue_empty();
 
     // Enqueue and process multiple test jobs to create archived jobs
@@ -914,14 +914,14 @@ async fn archive_conditionally() -> anyhow::Result<()> {
 
     // Configure runner with predicate-based archiving
     let runner = Runner::new(pool.clone(), ())
-        .configure_queue("default", |queue| {
-            queue
+        .add_queue(
+            Queue::default()
                 .register::<TestJob>()
                 .archive(ArchivalPolicy::If(|job, _ctx| {
                     // Archive only even-numbered jobs, for a 50% sample
                     job.id % 2 == 0
-                }))
-        })
+                })),
+        )
         .shutdown_when_queue_empty();
 
     // Enqueue multiple test jobs
@@ -939,5 +939,31 @@ async fn archive_conditionally() -> anyhow::Result<()> {
         "Expected 2 successful jobs to be archived"
     );
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn show_potential_api() -> anyhow::Result<()> {
+    #[derive(Serialize, Deserialize)]
+    struct SomeJob;
+
+    impl BackgroundJob for SomeJob {
+        const JOB_TYPE: &'static str = "test_archive_conditionally";
+        type Context = ();
+
+        async fn run(&self, _ctx: Self::Context) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    let (pool, _container) = test_utils::setup_test_db().await?;
+
+    let _runner = Runner::new(pool, ())
+        .add_queue(
+            Queue::default()
+                .register::<SomeJob>()
+                .archive(ArchivalPolicy::If(|job, _ctx| job.id % 2 == 0)),
+        )
+        .shutdown_when_queue_empty();
     Ok(())
 }


### PR DESCRIPTION
After discussions in multiple issues and PRs like #22 and #20, I have taken it upon myself to make the Runner impossible to configure incorrectly.

- The default queue is no more.
- Jobs are no longer queue aware
  - Why should they be in the first place?
  - We had a weird flow where the Runner would manage the JobRegistry inside of the individual Queues inside of itself
- Users now configure queues first
  - a Runner cannot be configured without at least one queue set up
    - the Queue cannot be used if it is not configured with at least one job type
- ⚠️ the archive cleaner has not been adapted and is still mis-configurable pending the discussion in #20