### PR TITLE
Add Support for Per-Job Timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A robust async PostgreSQL-backed background job processing system. It features:
 - **Job deduplication** to prevent duplicate work
 - **Multiple job queues** with independent worker pools
 - **Automatic retry** with exponential backoff for failed jobs
+- **Per-job timeouts** to prevent long-running jobs from blocking the queue
 - **Graceful shutdown** and queue management
 - **Error tracking** with Sentry integration
 
@@ -73,6 +74,33 @@ let job = SendEmailJob {
 job.enqueue(&pool).await?;
 ```
 
+### Job Timeouts
+
+Prevent long-running jobs from blocking the queue by configuring timeouts at the queue level.
+Jobs that exceed their queue's timeout are cancelled and marked as failed, then retried according to the retry policy.
+
+```rust,ignore
+use std::time::Duration;
+
+let runner = Runner::new(pool, context)
+    .add_queue(
+        Queue::named("github")
+            .register::<FetchRepoJob>()
+            // All jobs in this queue timeout after 30s
+            .timeout(Duration::from_secs(30))  
+    );
+```
+
+
+> [!NOTE]
+> When a job times out:
+> - Jobs are not forcefully interrupted. They stop at the next `.await`
+> - Timed-out jobs will be retried from the beginning, not resumed (!)
+> - Jobs must be designed to be idempotent or handle partial execution safely
+> - Avoid holding Tokio mutexes across `.await` points where cancellation could leave shared state inconsistent
+
+See the [timeout](examples/timeout.rs) example for details on cancel safety considerations.
+
 ## Configuration
 
 ### Job Properties
@@ -80,7 +108,6 @@ job.enqueue(&pool).await?;
 - **`JOB_TYPE`**: Unique identifier for the job type
 - **`PRIORITY`**: Execution priority (higher values = higher priority)
 - **`DEDUPLICATED`**: Whether to prevent duplicate jobs with identical data
-- **`QUEUE`**: Queue name for job execution (defaults to "default")
 
 ### Queue Configuration
 
@@ -98,6 +125,7 @@ Each queue can be tuned independently based on the resource constraints and thro
 - **Worker count**: Number of concurrent workers per queue
 - **Poll interval**: How often workers check for new jobs
 - **Jitter**: Random time added to poll intervals to reduce thundering herd effects (default: 100ms)
+- **Timeout**: Optional duration after which jobs will be cancelled and marked as failed (applies to all jobs in the queue)
 - **Shutdown behavior**: Whether to stop when queue is empty
 - **Archive completed jobs**: Whether to archive successful jobs instead of deleting them
 

--- a/examples/timeout.rs
+++ b/examples/timeout.rs
@@ -1,0 +1,72 @@
+//! Job timeout example for the workers library.
+//!
+//! This example demonstrates queue-level timeouts.
+//!
+//! ## Cancel Safety
+//!
+//! When a job times out, it's cancelled at the next `.await` point.
+//! Jobs should be idempotent and avoid leaving shared state inconsistent.
+//!
+//! Run with: `cargo run --example timeout`
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use std::time::Duration;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+use workers::{BackgroundJob, Queue, Runner};
+
+#[derive(Serialize, Deserialize)]
+struct Job {
+    duration_ms: u64,
+}
+
+impl BackgroundJob for Job {
+    const JOB_TYPE: &'static str = "job";
+    type Context = ();
+
+    async fn run(&self, _ctx: Self::Context) -> Result<()> {
+        tokio::time::sleep(Duration::from_millis(self.duration_ms)).await;
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Setup database
+    let container = Postgres::default().start().await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let pool = PgPool::connect(&format!(
+        "postgresql://postgres:postgres@127.0.0.1:{port}/postgres"
+    ))
+    .await?;
+    sqlx::migrate!("./migrations").run(&pool).await?;
+
+    // Create queue with 1 second timeout
+    let runner = Runner::new(pool.clone(), ())
+        .add_queue(
+            Queue::default()
+                .register::<Job>()
+                .timeout(Duration::from_secs(1)),
+        )
+        .shutdown_when_queue_empty();
+
+    // Enqueue two jobs: one fast, one slow
+    Job { duration_ms: 100 }.enqueue(&pool).await?; // Will complete (100ms < 1s)
+    Job {
+        duration_ms: 10_000,
+    }
+    .enqueue(&pool)
+    .await?; // Will timeout (10s > 1s)
+
+    // Run and verify: fast job completes, slow job times out
+    runner.start().wait_for_shutdown().await;
+
+    let failed: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM background_jobs WHERE retries > 0")
+        .fetch_one(&pool)
+        .await?;
+
+    assert_eq!(failed, 1, "Expected 1 failed job (the slow one)");
+    Ok(())
+}

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -109,6 +109,7 @@ impl<Context: Clone + Send + Sync + 'static> Runner<Context, Configured> {
                     shutdown_when_queue_empty: self.shutdown_when_queue_empty,
                     poll_interval: queue.poll_interval,
                     jitter: queue.jitter,
+                    timeout: queue.timeout,
                     archive_completed_jobs: queue.archive_completed_jobs.clone(),
                 };
 
@@ -171,6 +172,7 @@ pub struct Queue<Context: Clone + Send + Sync + 'static, State = Unconfigured> {
     num_workers: usize,
     poll_interval: Duration,
     jitter: Duration,
+    timeout: Option<Duration>,
     archive_completed_jobs: ArchivalPolicy<Context>,
     _state: PhantomData<State>,
 }
@@ -183,6 +185,7 @@ impl<Context: Clone + Send + Sync + 'static> Default for Queue<Context, Unconfig
             num_workers: 1,
             poll_interval: DEFAULT_POLL_INTERVAL,
             jitter: DEFAULT_JITTER,
+            timeout: None,
             archive_completed_jobs: ArchivalPolicy::default(),
             _state: PhantomData,
         }
@@ -224,6 +227,18 @@ impl<Context: Clone + Send + Sync + 'static, State> Queue<Context, State> {
         self
     }
 
+    /// Set a timeout for all jobs in this queue.
+    ///
+    /// If set, jobs that run longer than this duration will be cancelled
+    /// and marked as failed, then retried according to the retry policy.
+    ///
+    /// Jobs in the same queue typically interact with the same upstream
+    /// resource, so they should share timeout characteristics.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+
     /// Set whether completed jobs should be archived instead of deleted.
     pub fn archive(mut self, policy: ArchivalPolicy<Context>) -> Self {
         self.archive_completed_jobs = policy;
@@ -239,6 +254,7 @@ impl<Context: Clone + Send + Sync + 'static, State> Queue<Context, State> {
             num_workers: self.num_workers,
             poll_interval: self.poll_interval,
             jitter: self.jitter,
+            timeout: self.timeout,
             archive_completed_jobs: self.archive_completed_jobs,
             _state: PhantomData,
         }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -21,6 +21,7 @@ pub(crate) struct Worker<Context> {
     pub(crate) shutdown_when_queue_empty: bool,
     pub(crate) poll_interval: Duration,
     pub(crate) jitter: Duration,
+    pub(crate) timeout: Option<Duration>,
     pub(crate) archive_completed_jobs: ArchivalPolicy<Context>,
 }
 
@@ -106,17 +107,40 @@ impl<Context: Clone + Send + Sync + 'static> Worker<Context> {
         debug!("Running job…");
         let should_archive = self.should_archive(&job, &context);
 
+        let timeout = self.timeout;
         let future = with_sentry_transaction(&job.job_type, async || {
             let run_task_fn = job_registry
                 .get(&job.job_type)
                 .ok_or_else(|| anyhow!("Unknown job type {}", job.job_type))?;
 
-            AssertUnwindSafe(run_task_fn(context, job.data))
-                .catch_unwind()
-                .await
-                .map_err(|e| try_to_extract_panic_info(&*e))
-                // TODO: Replace with flatten() once that stabilizes
-                .and_then(std::convert::identity)
+            let job_future = async {
+                AssertUnwindSafe(run_task_fn(context, job.data))
+                    // Catch unwinding panics while the future is polling
+                    // We do this to prevent the whole worker from crashing
+                    // Instead, we can mark the job as failed and continue with the next one
+                    .catch_unwind()
+                    .await
+                    .map_err(|e| try_to_extract_panic_info(&*e))
+                    .flatten()
+            };
+
+            // Apply timeout if configured for this queue
+            //
+            // IMPORTANT: Timeout behavior and cancel safety
+            //
+            // Jobs with timeouts MUST be designed with cancellation in mind:
+            // - Jobs should be idempotent (safe to run multiple times)
+            // - Avoid leaving shared state in invalid states across .await points
+            // - Don't hold locks across .await points where cancellation could
+            //   leave data in an inconsistent state
+            if let Some(timeout_duration) = timeout {
+                match tokio::time::timeout(timeout_duration, job_future).await {
+                    Ok(result) => result,
+                    Err(_) => Err(anyhow!("Job timed out after {timeout_duration:?}")),
+                }
+            } else {
+                job_future.await
+            }
         });
 
         let result = future

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -941,3 +941,156 @@ async fn archive_conditionally() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+const DEFAULT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(100);
+
+#[tokio::test]
+async fn job_timeout_triggers_failure_and_retry() -> anyhow::Result<()> {
+    #[derive(Serialize, Deserialize)]
+    struct TimeoutJob;
+
+    impl BackgroundJob for TimeoutJob {
+        const JOB_TYPE: &'static str = "timeout_test";
+        type Context = ();
+
+        async fn run(&self, _ctx: Self::Context) -> anyhow::Result<()> {
+            // Sleep longer than the timeout
+            tokio::time::sleep(DEFAULT_TIMEOUT * 2).await;
+            Ok(())
+        }
+    }
+
+    let (pool, _container) = test_utils::setup_test_db().await?;
+
+    let runner = test_utils::create_test_runner(pool.clone(), ()).add_queue(
+        Queue::default()
+            .register::<TimeoutJob>()
+            .timeout(DEFAULT_TIMEOUT),
+    );
+
+    let job_id = assert_some!(TimeoutJob.enqueue(&pool).await?);
+
+    let runner = runner.start();
+    runner.wait_for_shutdown().await;
+
+    // Job should still exist (not deleted) because it failed
+    assert!(job_exists(job_id, &pool).await?);
+
+    // Retry counter should be incremented
+    let retries = sqlx::query_scalar::<_, i32>("SELECT retries FROM background_jobs WHERE id = $1")
+        .bind(job_id)
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(retries, 1);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn job_without_timeout_runs_indefinitely() -> anyhow::Result<()> {
+    #[derive(Serialize, Deserialize)]
+    struct SlowJob;
+
+    impl BackgroundJob for SlowJob {
+        const JOB_TYPE: &'static str = "slow_test";
+        // No timeout set
+        type Context = ();
+
+        async fn run(&self, _ctx: Self::Context) -> anyhow::Result<()> {
+            // Sleep for a relatively long time, but not forever
+            tokio::time::sleep(DEFAULT_TIMEOUT * 2).await;
+            Ok(())
+        }
+    }
+
+    let (pool, _container) = test_utils::setup_test_db().await?;
+
+    let runner = test_utils::create_test_runner(pool.clone(), ())
+        .add_queue(Queue::default().register::<SlowJob>());
+
+    let job_id = assert_some!(SlowJob.enqueue(&pool).await?);
+
+    let runner = runner.start();
+    runner.wait_for_shutdown().await;
+
+    // Job should be deleted (successfully completed)
+    assert!(!job_exists(job_id, &pool).await?);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn job_with_timeout_completes_before_timeout() -> anyhow::Result<()> {
+    #[derive(Serialize, Deserialize)]
+    struct FastJob;
+
+    impl BackgroundJob for FastJob {
+        const JOB_TYPE: &'static str = "fast_timeout_test";
+        type Context = ();
+
+        async fn run(&self, _ctx: Self::Context) -> anyhow::Result<()> {
+            // Complete quickly, well before the timeout
+            tokio::time::sleep(DEFAULT_TIMEOUT / 2).await;
+            Ok(())
+        }
+    }
+
+    let (pool, _container) = test_utils::setup_test_db().await?;
+
+    let runner = test_utils::create_test_runner(pool.clone(), ()).add_queue(
+        Queue::default()
+            .register::<FastJob>()
+            .timeout(DEFAULT_TIMEOUT),
+    );
+
+    let job_id = assert_some!(FastJob.enqueue(&pool).await?);
+
+    let runner = runner.start();
+    runner.wait_for_shutdown().await;
+
+    // Job should be deleted (successfully completed)
+    assert!(!job_exists(job_id, &pool).await?);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn timeout_job_archived_after_success() -> anyhow::Result<()> {
+    #[derive(Serialize, Deserialize)]
+    struct QuickJob;
+
+    impl BackgroundJob for QuickJob {
+        const JOB_TYPE: &'static str = "quick_archived_test";
+        type Context = ();
+
+        async fn run(&self, _ctx: Self::Context) -> anyhow::Result<()> {
+            // Complete quickly
+            Ok(())
+        }
+    }
+
+    let (pool, _container) = test_utils::setup_test_db().await?;
+
+    // Configure runner with archiving enabled and timeout
+    let runner = Runner::new(pool.clone(), ())
+        .add_queue(
+            Queue::default()
+                .register::<QuickJob>()
+                .timeout(DEFAULT_TIMEOUT)
+                .archive(ArchivalPolicy::Always),
+        )
+        .shutdown_when_queue_empty();
+
+    let job_id = assert_some!(QuickJob.enqueue(&pool).await?);
+
+    let runner = runner.start();
+    runner.wait_for_shutdown().await;
+
+    // Job should be deleted from active queue
+    assert!(!job_exists(job_id, &pool).await?);
+
+    // Job should be archived
+    assert_eq!(archived_job_count(&pool).await?, 1);
+
+    Ok(())
+}


### PR DESCRIPTION
To prevent long-running jobs from blocking the queue, we can now set an optional duration, after which the job will be interrupted (as in: the future will be canceled and its `Drop` impl will run) and marked as failed.